### PR TITLE
Close body even if it got error http status.

### DIFF
--- a/http.go
+++ b/http.go
@@ -174,10 +174,10 @@ func (h *httpGetter) Get(context Context, in *pb.GetRequest, out *pb.GetResponse
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("server returned: %v", res.Status)
 	}
-	defer res.Body.Close()
 	// TODO: avoid this garbage.
 	b, err := ioutil.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
Otherwise, http connections keep open if server
returned error status (e.g. Get returned error).
