### PR TITLE
HTTPPool increments Group.Stats.ServerRequests

### DIFF
--- a/http.go
+++ b/http.go
@@ -130,6 +130,8 @@ func (p *HTTPPool) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if p.Context != nil {
 		ctx = p.Context(r)
 	}
+
+	group.Stats.ServerRequests.Add(1)
 	var value []byte
 	err = group.Get(ctx, key, AllocatingByteSliceSink(&value))
 	if err != nil {


### PR DESCRIPTION
If you'd rather remove the stat, then that's fines.  I was assuming it was being incremented by the internal stubby implementation and got left out of the open source version.
