### PR TITLE
removed extra url-unescaping in http pool 

### DIFF
--- a/http.go
+++ b/http.go
@@ -109,16 +109,8 @@ func (p *HTTPPool) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	groupName, err := url.QueryUnescape(parts[0])
-	if err != nil {
-		http.Error(w, "decoding group: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	key, err := url.QueryUnescape(parts[1])
-	if err != nil {
-		http.Error(w, "decoding key: "+err.Error(), http.StatusBadRequest)
-		return
-	}
+	groupName := parts[0]
+	key := parts[1]
 
 	// Fetch the value for this group/key.
 	group := GetGroup(groupName)
@@ -133,7 +125,7 @@ func (p *HTTPPool) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	group.Stats.ServerRequests.Add(1)
 	var value []byte
-	err = group.Get(ctx, key, AllocatingByteSliceSink(&value))
+	err := group.Get(ctx, key, AllocatingByteSliceSink(&value))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
This fixes the bug described in https://github.com/golang/groupcache/issues/25
