### PR TITLE
changed default number of replicas in http pool hash ring to 50

### DIFF
--- a/consistenthash/consistenthash_test.go
+++ b/consistenthash/consistenthash_test.go
@@ -93,7 +93,7 @@ func BenchmarkGet512(b *testing.B) { benchmarkGet(b, 512) }
 
 func benchmarkGet(b *testing.B, shards int) {
 
-	hash := New(shards, nil)
+	hash := New(50, nil)
 
 	var buckets []string
 	for i := 0; i < shards; i++ {

--- a/http.go
+++ b/http.go
@@ -33,7 +33,7 @@ import (
 const defaultBasePath = "/_groupcache/"
 
 // TODO: make this configurable as well.
-const defaultReplicas = 3
+const defaultReplicas = 50
 
 // HTTPPool implements PeerPicker for a pool of HTTP peers.
 type HTTPPool struct {


### PR DESCRIPTION
Fixes https://github.com/golang/groupcache/issues/29
