### PR TITLE
add http.ResponseWriter to Context

### DIFF
--- a/http.go
+++ b/http.go
@@ -40,7 +40,7 @@ type HTTPPool struct {
 	// Context optionally specifies a context for the server to use when it
 	// receives a request.
 	// If nil, the server uses a nil Context.
-	Context func(*http.Request) Context
+	Context func(w http.ResponseWriter, req *http.Request) Context
 
 	// Transport optionally specifies an http.RoundTripper for the client
 	// to use when it makes a request.
@@ -120,7 +120,7 @@ func (p *HTTPPool) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	var ctx Context
 	if p.Context != nil {
-		ctx = p.Context(r)
+		ctx = p.Context(w, r)
 	}
 
 	group.Stats.ServerRequests.Add(1)


### PR DESCRIPTION
When I use groupcache,I have to track some fields of http header from back service, and the only way I found is to extend groupcache Context.