### PR TITLE
Prevent any queued calls between Done signal and key delete

### DIFF
--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -54,9 +54,9 @@ func (g *Group) Do(key string, fn func() (interface{}, error)) (interface{}, err
 	g.mu.Unlock()
 
 	c.val, c.err = fn()
-	c.wg.Done()
 
 	g.mu.Lock()
+	c.wg.Done()
 	delete(g.m, key)
 	g.mu.Unlock()
 


### PR DESCRIPTION
Having the `.Done()` call outside the mutex seems to leave a window where new calls could grab the lock and queue before the map key is deleted.  In this case a call would hang indefinitely.
