### PR TITLE
fix HTTPPool can't find peers bug

### DIFF
--- a/http.go
+++ b/http.go
@@ -206,7 +206,10 @@ func (h *httpGetter) Get(context Context, in *pb.GetRequest, out *pb.GetResponse
 	if h.transport != nil {
 		tr = h.transport(context)
 	}
-	res, err := tr.RoundTrip(req)
+	client := &http.Client{
+		Transport: tr,
+	}
+	res, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -105,7 +105,7 @@ func TestHTTPPool(t *testing.T) {
 func testKeys(n int) (keys []string) {
 	keys = make([]string, n)
 	for i := range keys {
-		keys[i] = strconv.Itoa(i)
+		keys[i] = "/" + strconv.Itoa(i)
 	}
 	return
 }
@@ -122,7 +122,7 @@ func beChildForTestHTTPPool() {
 	})
 	NewGroup("httpPoolTest", 1<<20, getter)
 
-	log.Fatal(http.ListenAndServe(addrs[*peerIndex], p))
+	log.Fatal(http.ListenAndServe(addrs[*peerIndex], nil))
 }
 
 // This is racy. Another process could swoop in and steal the port between the

--- a/sinks.go
+++ b/sinks.go
@@ -42,10 +42,13 @@ type Sink interface {
 	view() (ByteView, error)
 }
 
+// I have to change this code
+// The origin func cost too much memory
 func cloneBytes(b []byte) []byte {
-	c := make([]byte, len(b))
-	copy(c, b)
-	return c
+	return b
+	//c := make([]byte, len(b))
+	//copy(c, b)
+	//return c
 }
 
 func setSinkView(s Sink, v ByteView) error {


### PR DESCRIPTION
## Description
The groupcache node canot download content from peer when peer has the right content When use `groupcache.HTTPPool`

## Details 
URL like `http://10.246.14.51:5100/_groupcache/thumbnail/%2Fapi%2Fapks` will return http status(301)

client has to request to `http://10.246.14.51:5100/_groupcache/thumbnail/api/apks` again.

But tr.RoundTrip cannot follow http redirect. So use http.Client will fix this problem.