### PR TITLE
typo

### DIFF
--- a/http.go
+++ b/http.go
@@ -74,7 +74,7 @@ type HTTPPoolOptions struct {
 
 // NewHTTPPool initializes an HTTP pool of peers, and registers itself as a PeerPicker.
 // For convenience, it also registers itself as an http.Handler with http.DefaultServeMux.
-// The self argument be a valid base URL that points to the current server,
+// The self argument must be a valid base URL that points to the current server,
 // for example "http://example.net:8000".
 func NewHTTPPool(self string) *HTTPPool {
 	p := NewHTTPPoolOpts(self, nil)


### PR DESCRIPTION
Could be a "should", but seems like it should be a "must".