### PR TITLE
HTTPPool support for per-group peers with no changes to the existing API

### DIFF
--- a/groupcache.go
+++ b/groupcache.go
@@ -198,7 +198,7 @@ func (g *Group) Name() string {
 
 func (g *Group) initPeers() {
 	if g.peers == nil {
-		g.peers = getPeers()
+		g.peers = getPeers(g.name)
 	}
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -32,10 +32,21 @@ import (
 )
 
 var (
-	peerAddrs = flag.String("test_peer_addrs", "", "Comma-separated list of peer addresses; used by TestHTTPPool")
-	peerIndex = flag.Int("test_peer_index", -1, "Index of which peer this child is; used by TestHTTPPool")
-	peerChild = flag.Bool("test_peer_child", false, "True if running as a child process; used by TestHTTPPool")
+	defaultGroup = "httpPoolTest"
+	otherGroup1  = "httpPoolTest1"
+	otherGroup2  = "httpPoolTest2"
+	offGroup     = "off"
+
+	peerSelfAddr = flag.String("test_self_addr", "", "Self address; used by TestHTTPPool")
+	peerIndex    = flag.Int("test_peer_index", -1, "Index of which peer this child is; used by TestHTTPPool")
+	peerAddrs1   = flag.String("test_peer_addrs1", "", "Comma-separated list of first group peer addresses; used by TestHTTPPool")
+	groupName1   = flag.String("test_group_name1", defaultGroup, "Name of the first group used for groupcache; used by TestHTTPPool")
+	peerAddrs2   = flag.String("test_peer_addrs2", "", "Comma-separated list of second group peer addresses; used by TestHTTPPool")
+	groupName2   = flag.String("test_group_name2", offGroup, "Name of the second group used for groupcache; used by TestHTTPPool")
+	peerChild    = flag.Bool("test_peer_child", false, "True if running as a child process; used by TestHTTPPool")
 )
+
+const nGets = 100
 
 func TestHTTPPool(t *testing.T) {
 	if *peerChild {
@@ -43,40 +54,23 @@ func TestHTTPPool(t *testing.T) {
 		os.Exit(0)
 	}
 
-	const (
-		nChild = 4
-		nGets  = 100
-	)
+	const nChild = 4
 
 	var childAddr []string
 	for i := 0; i < nChild; i++ {
 		childAddr = append(childAddr, pickFreeAddr(t))
 	}
 
-	var cmds []*exec.Cmd
-	var wg sync.WaitGroup
-	for i := 0; i < nChild; i++ {
-		cmd := exec.Command(os.Args[0],
-			"--test.run=TestHTTPPool",
-			"--test_peer_child",
-			"--test_peer_addrs="+strings.Join(childAddr, ","),
-			"--test_peer_index="+strconv.Itoa(i),
-		)
-		cmds = append(cmds, cmd)
-		wg.Add(1)
-		if err := cmd.Start(); err != nil {
-			t.Fatal("failed to start child process: ", err)
-		}
-		go awaitAddrReady(t, childAddr[i], &wg)
-	}
+	cmds := buildCommandsAndRun("TestHTTPPool", t, 0, nChild, childAddr, childAddr, nil, defaultGroup, offGroup)
 	defer func() {
+		httpPoolMade = false
+		portPicker = nil
 		for i := 0; i < nChild; i++ {
 			if cmds[i].Process != nil {
 				cmds[i].Process.Kill()
 			}
 		}
 	}()
-	wg.Wait()
 
 	// Use a dummy self address so that we don't handle gets in-process.
 	p := NewHTTPPool("should-be-ignored")
@@ -88,18 +82,117 @@ func TestHTTPPool(t *testing.T) {
 	getter := GetterFunc(func(ctx Context, key string, dest Sink) error {
 		return errors.New("parent getter called; something's wrong")
 	})
-	g := NewGroup("httpPoolTest", 1<<20, getter)
+	g := NewGroup(defaultGroup, 1<<20, getter)
 
+	testGroup(t, defaultGroup, g)
+}
+
+func TestHTTPPoolPeerPicker(t *testing.T) {
+	if *peerChild {
+		beChildForTestHTTPPool()
+		os.Exit(0)
+	}
+
+	const (
+		nChild   = 2
+		nOverlap = 2
+	)
+
+	var allChildAddrs []string
+	var childAddr1 []string
+	var childAddr2 []string
+	for i := 0; i < nChild; i++ {
+		freeAddr := pickFreeAddr(t)
+		allChildAddrs = append(allChildAddrs, freeAddr)
+		childAddr1 = append(childAddr1, freeAddr)
+	}
+	for i := 0; i < nChild; i++ {
+		freeAddr := pickFreeAddr(t)
+		allChildAddrs = append(allChildAddrs, freeAddr)
+		childAddr1 = append(childAddr1, freeAddr)
+		childAddr2 = append(childAddr2, freeAddr)
+	}
+	for i := 0; i < nChild; i++ {
+		freeAddr := pickFreeAddr(t)
+		allChildAddrs = append(allChildAddrs, freeAddr)
+		childAddr2 = append(childAddr2, freeAddr)
+	}
+
+	cmds1 := buildCommandsAndRun("TestHTTPPoolPeerPicker", t, 0, nChild, allChildAddrs, childAddr1, nil, otherGroup1, offGroup)
+	cmds2 := buildCommandsAndRun("TestHTTPPoolPeerPicker", t, nChild, nChild+nOverlap, allChildAddrs, childAddr1, childAddr2, otherGroup1, otherGroup2)
+	cmds3 := buildCommandsAndRun("TestHTTPPoolPeerPicker", t, nChild+nOverlap, 2*nChild+nOverlap, allChildAddrs, nil, childAddr2, offGroup, otherGroup2)
+
+	defer func() {
+		httpPoolMade = false
+		portPicker = nil
+		for _, cmd := range append(append(cmds1, cmds2...), cmds3...) {
+			if cmd.Process != nil {
+				cmd.Process.Kill()
+			}
+		}
+	}()
+
+	// Use a dummy self address so that we don't handle gets in-process.
+	h := new(HTTPPoolOptions)
+	h.PerGroupPeerPicker = true
+	p := NewHTTPPoolOpts("should-be-ignored", h)
+
+	// Dummy getter function. Gets should go to children only.
+	// The only time this process will handle a get is when the
+	// children can't be contacted for some reason.
+	getter := GetterFunc(func(ctx Context, key string, dest Sink) error {
+		return errors.New("parent getter called; something's wrong")
+	})
+	g1 := NewGroup(otherGroup1, 1<<20, getter)
+	p.SetGroupPeers(otherGroup1, addrToURL(childAddr1)...)
+	g2 := NewGroup(otherGroup2, 1<<20, getter)
+	p.SetGroupPeers(otherGroup2, addrToURL(childAddr2)...)
+
+	testGroup(t, otherGroup1, g1)
+	testGroup(t, otherGroup2, g2)
+}
+
+func testGroup(t *testing.T, groupName string, g *Group) {
 	for _, key := range testKeys(nGets) {
 		var value string
 		if err := g.Get(nil, key, StringSink(&value)); err != nil {
 			t.Fatal(err)
 		}
-		if suffix := ":" + key; !strings.HasSuffix(value, suffix) {
+		if suffix := ":" + groupName + ":" + key; !strings.HasSuffix(value, suffix) {
 			t.Errorf("Get(%q) = %q, want value ending in %q", key, value, suffix)
 		}
-		t.Logf("Get key=%q, value=%q (peer:key)", key, value)
+		t.Logf("Get key=%q, value=%q (peer:groupname:key)", key, value)
 	}
+}
+
+func buildCommandsAndRun(test string, t *testing.T, startIndex, endIndex int, allChildAddrs, childAddrSlice1, childAddrSlice2 []string, groupNameStr1, groupNameStr2 string) []*exec.Cmd {
+	var cmds []*exec.Cmd
+	var wg sync.WaitGroup
+	for i := startIndex; i < endIndex; i++ {
+		cmd := exec.Command(os.Args[0],
+			"--test.run="+test,
+			"--test_peer_child",
+			"--test_peer_index="+strconv.Itoa(i),
+			"--test_peer_addrs1="+strings.Join(childAddrSlice1, ","),
+			"--test_group_name1="+groupNameStr1,
+			"--test_peer_addrs2="+strings.Join(childAddrSlice2, ","),
+			"--test_group_name2="+groupNameStr2,
+			"--test_self_addr="+allChildAddrs[i],
+		)
+		// fmt.Println(cmd.Args)
+		// if i == 2 {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		// }
+		cmds = append(cmds, cmd)
+		wg.Add(1)
+		if err := cmd.Start(); err != nil {
+			t.Fatal("failed to start child process: ", err)
+		}
+		go awaitAddrReady(t, allChildAddrs[i], &wg)
+	}
+	wg.Wait()
+	return cmds
 }
 
 func testKeys(n int) (keys []string) {
@@ -111,18 +204,51 @@ func testKeys(n int) (keys []string) {
 }
 
 func beChildForTestHTTPPool() {
-	addrs := strings.Split(*peerAddrs, ",")
+	if *groupName1 == offGroup || *groupName2 == offGroup {
+		var addrs []string
+		var groupName string
+		if *groupName2 == offGroup {
+			addrs = strings.Split(*peerAddrs1, ",")
+			groupName = *groupName1
+		} else {
+			addrs = strings.Split(*peerAddrs2, ",")
+			groupName = *groupName2
+		}
 
-	p := NewHTTPPool("http://" + addrs[*peerIndex])
-	p.Set(addrToURL(addrs)...)
+		p := NewHTTPPool("http://" + *peerSelfAddr)
+		p.Set(addrToURL(addrs)...)
 
-	getter := GetterFunc(func(ctx Context, key string, dest Sink) error {
-		dest.SetString(strconv.Itoa(*peerIndex) + ":" + key)
-		return nil
-	})
-	NewGroup("httpPoolTest", 1<<20, getter)
+		getter := GetterFunc(func(ctx Context, key string, dest Sink) error {
+			dest.SetString(strconv.Itoa(*peerIndex) + ":" + groupName + ":" + key)
+			return nil
+		})
+		NewGroup(groupName, 1<<20, getter)
 
-	log.Fatal(http.ListenAndServe(addrs[*peerIndex], p))
+		log.Fatal(http.ListenAndServe(*peerSelfAddr, p))
+	} else {
+		addrs1 := strings.Split(*peerAddrs1, ",")
+		addrs2 := strings.Split(*peerAddrs2, ",")
+
+		h := new(HTTPPoolOptions)
+		h.PerGroupPeerPicker = true
+		p := NewHTTPPoolOpts("http://"+*peerSelfAddr, h)
+
+		// TODO change to specific groups
+		getter1 := GetterFunc(func(ctx Context, key string, dest Sink) error {
+			dest.SetString(strconv.Itoa(*peerIndex) + ":" + *groupName1 + ":" + key)
+			return nil
+		})
+		getter2 := GetterFunc(func(ctx Context, key string, dest Sink) error {
+			dest.SetString(strconv.Itoa(*peerIndex) + ":" + *groupName2 + ":" + key)
+			return nil
+		})
+		NewGroup(*groupName1, 1<<20, getter1)
+		p.SetGroupPeers(*groupName1, addrToURL(addrs1)...)
+		NewGroup(*groupName2, 1<<20, getter2)
+		p.SetGroupPeers(*groupName2, addrToURL(addrs2)...)
+
+		log.Fatal(http.ListenAndServe(*peerSelfAddr, p))
+	}
 }
 
 // This is racy. Another process could swoop in and steal the port between the

--- a/peers.go
+++ b/peers.go
@@ -47,23 +47,37 @@ type NoPeers struct{}
 func (NoPeers) PickPeer(key string) (peer ProtoGetter, ok bool) { return }
 
 var (
-	portPicker func() PeerPicker
+	portPicker func(groupName string) PeerPicker
 )
 
 // RegisterPeerPicker registers the peer initialization function.
 // It is called once, when the first group is created.
+// Either RegisterPeerPicker or RegisterPerGroupPeerPicker should be
+// called exactly once, but not both.
 func RegisterPeerPicker(fn func() PeerPicker) {
+	if portPicker != nil {
+		panic("RegisterPeerPicker called more than once")
+	}
+	portPicker = func(_ string) PeerPicker { return fn() }
+}
+
+// RegisterPerGroupPeerPicker registers the peer initialization function,
+// which takes the groupName, to be used in choosing a PeerPicker.
+// It is called once, when the first group is created.
+// Either RegisterPeerPicker or RegisterPerGroupPeerPicker should be
+// called exactly once, but not both.
+func RegisterPerGroupPeerPicker(fn func(groupName string) PeerPicker) {
 	if portPicker != nil {
 		panic("RegisterPeerPicker called more than once")
 	}
 	portPicker = fn
 }
 
-func getPeers() PeerPicker {
+func getPeers(groupName string) PeerPicker {
 	if portPicker == nil {
 		return NoPeers{}
 	}
-	pk := portPicker()
+	pk := portPicker(groupName)
 	if pk == nil {
 		pk = NoPeers{}
 	}

--- a/peers.go
+++ b/peers.go
@@ -56,7 +56,7 @@ var (
 // called exactly once, but not both.
 func RegisterPeerPicker(fn func() PeerPicker) {
 	if portPicker != nil {
-		panic("RegisterPeerPicker called more than once")
+		panic("RegisterPeerPicker or RegisterPerGroupPeerPicker should be called exactly once, and you cannot call both.")
 	}
 	portPicker = func(_ string) PeerPicker { return fn() }
 }
@@ -68,7 +68,7 @@ func RegisterPeerPicker(fn func() PeerPicker) {
 // called exactly once, but not both.
 func RegisterPerGroupPeerPicker(fn func(groupName string) PeerPicker) {
 	if portPicker != nil {
-		panic("RegisterPeerPicker called more than once")
+		panic("RegisterPeerPicker or RegisterPerGroupPeerPicker should be called exactly once, and you cannot call both.")
 	}
 	portPicker = fn
 }


### PR DESCRIPTION
The HTTP changes from https://github.com/golang/groupcache/pull/69.

Dependent on https://github.com/golang/groupcache/pull/70.
