### PR TITLE
Add GetN() to consistenthash

### DIFF
--- a/consistenthash/consistenthash_test.go
+++ b/consistenthash/consistenthash_test.go
@@ -62,7 +62,78 @@ func TestHashing(t *testing.T) {
 			t.Errorf("Asking for %s, should have yielded %s", k, v)
 		}
 	}
+}
 
+func TestGetN(t *testing.T) {
+	// Override the hash function to return easier to reason about values. Assumes
+	// the keys can be converted to an integer.
+	hash := New(1, func(key []byte) uint32 {
+		i, err := strconv.Atoi(string(key))
+		if err != nil {
+			panic(err)
+		}
+		return uint32(i)
+	})
+
+	if len(hash.GetN("1", 1, nil)) > 0 {
+		t.Errorf("Should not be able to get items from empty ring")
+	}
+
+	hash.Add("6", "1337", "1236", "1723")
+	if res := hash.GetN("1", 0, nil); len(res) > 0 {
+		t.Errorf("Asked for 0 items but got %d items instead", len(res))
+	}
+
+	testCases := map[string][]string{
+		"1235": []string{"1236", "1337", "1723"},
+		"1236": []string{"1236", "1337", "1723"},
+		"1237": []string{"1337", "1723", "6"},
+		"1238": []string{"1337", "1723", "6"},
+		"1338": []string{"1723", "6", "1236"},
+	}
+
+	for k, v := range testCases {
+		res := hash.GetN(k, 3, nil)
+		if len(res) != 3 {
+			t.Errorf("Asking for %s, should have yielded %s, but got: %s", k, v, res)
+			continue
+		}
+
+		for i, resV := range res {
+			if v[i] != resV {
+				t.Errorf("Asking for %s, should have yielded %s, but got: %s", k, v, res)
+			}
+		}
+	}
+
+	// Verify ring size (in this case 4) is used as upper bound
+	if res := hash.GetN("9999", 10, nil); len(res) > 4 {
+		t.Errorf("Ring only contains 4 items but we received %d: %s", len(res), res)
+	}
+}
+
+func TestGetNWithReplicas(t *testing.T) {
+	hash := New(250, nil)
+	hash.Add("6", "1337", "1236", "1723")
+
+	testCases := map[string][]string{
+		"1338": []string{"6", "1337", "1723"}, // [6 1337 1337 6 1723]
+		"1238": []string{"1236", "6", "1337"}, // [1236 6 6 1236 1337]
+	}
+
+	for k, v := range testCases {
+		res := hash.GetN(k, 3, AcceptUnique)
+		if len(res) != 3 {
+			t.Errorf("Asking for %s, should have yielded %s, but got: %s", k, v, res)
+			continue
+		}
+
+		for i, resV := range res {
+			if v[i] != resV {
+				t.Errorf("Asking for %s, should have yielded %s, but got: %s", k, v, res)
+			}
+		}
+	}
 }
 
 func TestConsistency(t *testing.T) {


### PR DESCRIPTION
I'm using the consistenthash library without the rest of the groupcache code base. I'd like to be able to store a single item on multiple physical nodes that are spread over multiple data centers. The GetN() function introduced in this PR should allow for that.