### PR TITLE
http.go: Added missing word from NewHTTPPool docs

### DIFF
--- a/http.go
+++ b/http.go
@@ -74,7 +74,7 @@ type HTTPPoolOptions struct {
 
 // NewHTTPPool initializes an HTTP pool of peers, and registers itself as a PeerPicker.
 // For convenience, it also registers itself as an http.Handler with http.DefaultServeMux.
-// The self argument be a valid base URL that points to the current server,
+// The self argument should be a valid base URL that points to the current server,
 // for example "http://example.net:8000".
 func NewHTTPPool(self string) *HTTPPool {
 	p := NewHTTPPoolOpts(self, nil)


### PR DESCRIPTION
Not sure if the phrase is supposed to be "should be", "can be", "must be", or something else, but based on the other docs, my guess is "should", but please fix this in any case.

Thanks!