### PR TITLE
Implement WriterTo

### DIFF
--- a/byteview.go
+++ b/byteview.go
@@ -158,3 +158,18 @@ func (v ByteView) ReadAt(p []byte, off int64) (n int, err error) {
 	}
 	return
 }
+
+// WriteTo implements io.WriterTo on the bytes in v.
+func (v ByteView) WriteTo(w io.Writer) (n int64, err error) {
+	var m int
+	if v.b != nil {
+		m, err = w.Write(v.b)
+	} else {
+		m, err = io.WriteString(w, v.s)
+	}
+	if err == nil && m < v.Len() {
+		err = io.ErrShortWrite
+	}
+	n = int64(m)
+	return
+}

--- a/byteview_test.go
+++ b/byteview_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package groupcache
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -46,6 +47,10 @@ func TestByteView(t *testing.T) {
 			}
 			if got, err := ioutil.ReadAll(io.NewSectionReader(v, 0, int64(len(s)))); err != nil || string(got) != s {
 				t.Errorf("%s: SectionReader of ReaderAt = %q, %v; want %q", name, got, err, s)
+			}
+			var dest bytes.Buffer
+			if _, err := v.WriteTo(&dest); err != nil || !bytes.Equal(dest.Bytes(), []byte(s)) {
+				t.Errorf("%s: WriteTo = %q, %v; want %q", name, dest.Bytes(), err, s)
 			}
 		}
 	}


### PR DESCRIPTION
Avoids allocation/copy when writing byteview to a writer.