### PR TITLE
Adhering to go style variable declarations

### DIFF
--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -258,7 +258,7 @@ func TestPeers(t *testing.T) {
 	peer2 := &fakePeer{}
 	peerList := fakePeers([]ProtoGetter{peer0, peer1, peer2, nil})
 	const cacheSize = 0 // disabled
-	localHits := 0
+	var localHits int
 	getter := func(_ Context, key string, dest Sink) error {
 		localHits++
 		return dest.SetString("got:" + key)

--- a/http_test.go
+++ b/http_test.go
@@ -149,7 +149,7 @@ func addrToURL(addr []string) []string {
 func awaitAddrReady(t *testing.T, addr string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	const max = 1 * time.Second
-	tries := 0
+	var tries int
 	for {
 		tries++
 		c, err := net.Dial("tcp", addr)


### PR DESCRIPTION
Prefer variable declarations adhering to go style, `var a int` over `a := 0`