### PR TITLE
Format error string as per go style

### DIFF
--- a/singleflight/singleflight_test.go
+++ b/singleflight/singleflight_test.go
@@ -40,7 +40,7 @@ func TestDo(t *testing.T) {
 
 func TestDoErr(t *testing.T) {
 	var g Group
-	someErr := errors.New("Some error")
+	someErr := errors.New("some error")
 	v, err := g.Do("key", func() (interface{}, error) {
 		return nil, someErr
 	})


### PR DESCRIPTION
Error strings should not start with a capitalised letter, as per go style prescribed in the [Wiki](https://github.com/golang/go/wiki/Errors).