### PR TITLE
Use standard library's context.Context

### DIFF
--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package groupcache
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -41,7 +42,7 @@ var (
 
 	stringc = make(chan string)
 
-	dummyCtx Context
+	dummyCtx = context.TODO()
 
 	// cacheFills is the number of times stringGroup or
 	// protoGroup's Getter have been called. Read using the
@@ -58,7 +59,7 @@ const (
 )
 
 func testSetup() {
-	stringGroup = NewGroup(stringGroupName, cacheSize, GetterFunc(func(_ Context, key string, dest Sink) error {
+	stringGroup = NewGroup(stringGroupName, cacheSize, GetterFunc(func(_ context.Context, key string, dest Sink) error {
 		if key == fromChan {
 			key = <-stringc
 		}
@@ -66,7 +67,7 @@ func testSetup() {
 		return dest.SetString("ECHO:" + key)
 	}))
 
-	protoGroup = NewGroup(protoGroupName, cacheSize, GetterFunc(func(_ Context, key string, dest Sink) error {
+	protoGroup = NewGroup(protoGroupName, cacheSize, GetterFunc(func(_ context.Context, key string, dest Sink) error {
 		if key == fromChan {
 			key = <-stringc
 		}
@@ -230,7 +231,7 @@ type fakePeer struct {
 	fail bool
 }
 
-func (p *fakePeer) Get(_ Context, in *pb.GetRequest, out *pb.GetResponse) error {
+func (p *fakePeer) Get(_ context.Context, in *pb.GetRequest, out *pb.GetResponse) error {
 	p.hits++
 	if p.fail {
 		return errors.New("simulated error from peer")
@@ -259,7 +260,7 @@ func TestPeers(t *testing.T) {
 	peerList := fakePeers([]ProtoGetter{peer0, peer1, peer2, nil})
 	const cacheSize = 0 // disabled
 	localHits := 0
-	getter := func(_ Context, key string, dest Sink) error {
+	getter := func(_ context.Context, key string, dest Sink) error {
 		localHits++
 		return dest.SetString("got:" + key)
 	}
@@ -387,7 +388,7 @@ func (g *orderedFlightGroup) Do(key string, fn func() (interface{}, error)) (int
 func TestNoDedup(t *testing.T) {
 	const testkey = "testkey"
 	const testval = "testval"
-	g := newGroup("testgroup", 1024, GetterFunc(func(_ Context, key string, dest Sink) error {
+	g := newGroup("testgroup", 1024, GetterFunc(func(_ context.Context, key string, dest Sink) error {
 		return dest.SetString(testval)
 	}), nil)
 

--- a/http_test.go
+++ b/http_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package groupcache
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"log"
@@ -85,7 +86,7 @@ func TestHTTPPool(t *testing.T) {
 	// Dummy getter function. Gets should go to children only.
 	// The only time this process will handle a get is when the
 	// children can't be contacted for some reason.
-	getter := GetterFunc(func(ctx Context, key string, dest Sink) error {
+	getter := GetterFunc(func(ctx context.Context, key string, dest Sink) error {
 		return errors.New("parent getter called; something's wrong")
 	})
 	g := NewGroup("httpPoolTest", 1<<20, getter)
@@ -116,7 +117,7 @@ func beChildForTestHTTPPool() {
 	p := NewHTTPPool("http://" + addrs[*peerIndex])
 	p.Set(addrToURL(addrs)...)
 
-	getter := GetterFunc(func(ctx Context, key string, dest Sink) error {
+	getter := GetterFunc(func(ctx context.Context, key string, dest Sink) error {
 		dest.SetString(strconv.Itoa(*peerIndex) + ":" + key)
 		return nil
 	})

--- a/peers.go
+++ b/peers.go
@@ -19,17 +19,14 @@ limitations under the License.
 package groupcache
 
 import (
+	"context"
+
 	pb "github.com/golang/groupcache/groupcachepb"
 )
 
-// Context is an opaque value passed through calls to the
-// ProtoGetter. It may be nil if your ProtoGetter implementation does
-// not require a context.
-type Context interface{}
-
 // ProtoGetter is the interface that must be implemented by a peer.
 type ProtoGetter interface {
-	Get(context Context, in *pb.GetRequest, out *pb.GetResponse) error
+	Get(context context.Context, in *pb.GetRequest, out *pb.GetResponse) error
 }
 
 // PeerPicker is the interface that must be implemented to locate


### PR DESCRIPTION
These changes replace the ad-hoc implementation of context with the standard library's version of context which has been available since Go 1.7.  This was previously discussed in #68 .
