### PR TITLE
[ISSUE-133] add go module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/golang/groupcache
+
+go 1.13
+
+require github.com/golang/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
+github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=


### PR DESCRIPTION
Fixes #133 

Simply adds the go.mod / go.sum files.

After merging the PR, a contributor should push a Git tag of the form `vX.Y.Z` to allow versioning.