### PR TITLE
Add validation to Set(peers ...string)

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -165,3 +165,51 @@ func awaitAddrReady(t *testing.T, addr string, wg *sync.WaitGroup) {
 		time.Sleep(delay)
 	}
 }
+
+func TestSet(t *testing.T) {
+	// list of peer addresses to test with, and whether or not we expect
+	// peer to be valid.
+	// TODO: add IPv6 addresses.
+	peers := map[string]bool{
+		//addres.......................valid
+		"http://10.0.0.1:8000":        true,
+		"https://example.com:8001":    true,
+		"http://sub.example.com:8002": true,
+		"https://localhost:8003":      true,
+
+		"10.0.0.1:8100":             false,
+		"example.com:8101":          false,
+		"sub.example.com:8102":      false,
+		"localhost:8103":            false,
+		"http:////example.com:8104": false,
+		"//example.com:8105":        false,
+		"httpss//example.com:8106":  false,
+		"hhttp//example.com:8107":   false,
+		"htxtp//example.com:8108":   false,
+		"http//example:8109":        false,
+		"http//example/path/:8110":  false,
+		"/":                         false,
+		"":                          false,
+		":8111":                     false,
+		":http://example.com":       false,
+	}
+
+	// create pool to use for testing, using a known
+	// good/valid address
+	pool := NewHTTPPool("http://localhost:8080")
+
+	// try setting peers
+	for addr, valid := range peers {
+		err := pool.Set(addr)
+		if valid && err != nil {
+			t.Fatal("Peer address NOT valid but should be: " + addr)
+			return
+		}
+		if !valid && err == nil {
+			t.Fatal("Peer address valid but should NOT be: " + addr)
+			return
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
Check if each `peers` input value to `Set(peers ...string)` is a valid base URL as required and as noted in the func-level comments.

The prior version of `Set()` did not include any validation of the input value(s) even though the func-level comments noted "Each peer value should be a valid base URL, for example 'http://example.net:8000'".  This could lead to confusion when a cluster of peers cannot communicate.  For example, if a user called `Set("localhost:8080")` this may look correct but the host on which `Set()` was called will not be able to communicate with the peer provided via the address `localhost:8080`.  This is compounded by the fact no error is returned, nor is anything logged, leading the user to believe the error is elsewhere besides with the inputted address.

To solve the above noted issue/confusion, `Set()` was modified to check if each input value is a valid URL and return an error when an input value is invalid.  This is done by checking if the input URL has the required scheme (http or https since groupcache only uses http based communication at this point) and if a host was provided.  Modifying the `Set()` func to return an `error` should not break anything since you can ignore return values from funcs.

The lines of code within the `Set()` func were reordered so that validation of input peer address could be done before setting of any pool data.