### PR TITLE
Added Support for Linux on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go_import_path: github.com/golang/groupcache
-
+arch:
+  - amd64
+  - ppc64le
 os: linux
 dist: trusty
 sudo: false


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/groupcache/builds/194925870
Please have a look.

Regards,
ujjwal