### PR TITLE
add back Context type as alias to context.Context

### DIFF
--- a/peers.go
+++ b/peers.go
@@ -24,6 +24,9 @@ import (
 	pb "github.com/golang/groupcache/groupcachepb"
 )
 
+// Context is an alias to context.Context for backwards compatibility purposes.
+type Context = context.Context
+
 // ProtoGetter is the interface that must be implemented by a peer.
 type ProtoGetter interface {
 	Get(ctx context.Context, in *pb.GetRequest, out *pb.GetResponse) error


### PR DESCRIPTION
Pull request #131 deleted the Context declaration,
which broke most usages of this package since users needed to implement
the interfaces mentioned in this package by referencing the
groupcache.Context type. However, that type was removed from peers.go
in the mentioned pull request.

Technically, #131 is a breaking change since groupcache.Context
was an interface{}, and the PR switched it to be context.Context.
Fortunately, it seems that all users are passing a context.Context
anyways so that the type safety just checks out.

However, most users are still referencing groupcache.Context.