### PR TITLE
fix function TestConsistency

### DIFF
--- a/consistenthash/consistenthash_test.go
+++ b/consistenthash/consistenthash_test.go
@@ -75,15 +75,6 @@ func TestConsistency(t *testing.T) {
 	if hash1.Get("Ben") != hash2.Get("Ben") {
 		t.Errorf("Fetching 'Ben' from both hashes should be the same")
 	}
-
-	hash2.Add("Becky", "Ben", "Bobby")
-
-	if hash1.Get("Ben") != hash2.Get("Ben") ||
-		hash1.Get("Bob") != hash2.Get("Bob") ||
-		hash1.Get("Bonny") != hash2.Get("Bonny") {
-		t.Errorf("Direct matches should always return the same entry")
-	}
-
 }
 
 func BenchmarkGet8(b *testing.B)   { benchmarkGet(b, 8) }

--- a/consistenthash/consistenthash_test.go
+++ b/consistenthash/consistenthash_test.go
@@ -75,6 +75,12 @@ func TestConsistency(t *testing.T) {
 	if hash1.Get("Ben") != hash2.Get("Ben") {
 		t.Errorf("Fetching 'Ben' from both hashes should be the same")
 	}
+
+	if hash1.Get("Bill0") != hash2.Get("Bill0") ||
+		hash1.Get("Bob0") != hash2.Get("Bob0") ||
+		hash1.Get("Bonny0") != hash2.Get("Bonny0") {
+		t.Errorf("Direct matches should always return the same entry")
+	}
 }
 
 func BenchmarkGet8(b *testing.B)   { benchmarkGet(b, 8) }

--- a/consistenthash/consistenthash_test.go
+++ b/consistenthash/consistenthash_test.go
@@ -75,10 +75,10 @@ func TestConsistency(t *testing.T) {
 	if hash1.Get("Ben") != hash2.Get("Ben") {
 		t.Errorf("Fetching 'Ben' from both hashes should be the same")
 	}
-
-	if hash1.Get("Bill0") != hash2.Get("Bill0") ||
-		hash1.Get("Bob0") != hash2.Get("Bob0") ||
-		hash1.Get("Bonny0") != hash2.Get("Bonny0") {
+	
+	if hash1.Get("0Bill") != hash2.Get("0Bill") ||
+		hash1.Get("0Bob") != hash2.Get("0Bob") ||
+		hash1.Get("0Bonny") != hash2.Get("0Bonny") {
 		t.Errorf("Direct matches should always return the same entry")
 	}
 }


### PR DESCRIPTION
The Add function does not add the hash value of the string key itself to the list keys, so what is the meaning of 'Direct match' in the sentence "Direct matches should always return the same entry", I think this is a bug in the test code, Does 'Direct match' mean that the queried string directly corresponds to a replicated node? So I made some changes to the code.