### PR TITLE
fix function TestConsistency

### DIFF
--- a/consistenthash/consistenthash_test.go
+++ b/consistenthash/consistenthash_test.go
@@ -78,9 +78,9 @@ func TestConsistency(t *testing.T) {
 
 	hash2.Add("Becky", "Ben", "Bobby")
 
-	if hash1.Get("Ben") != hash2.Get("Ben") ||
-		hash1.Get("Bob") != hash2.Get("Bob") ||
-		hash1.Get("Bonny") != hash2.Get("Bonny") {
+	if hash1.Get("0Bill") != hash2.Get("0Bill") ||
+		hash1.Get("0Bob") != hash2.Get("0Bob") ||
+		hash1.Get("0Bonny") != hash2.Get("0Bonny") {
 		t.Errorf("Direct matches should always return the same entry")
 	}
 


### PR DESCRIPTION
The Add function does not add the hash value of the string key itself to the list keys, so what is the meaning of 'Direct match' in the sentence "Direct matches should always return the same entry", I think this is a bug in the test code, Does 'Direct match' mean that the queried string directly corresponds to a replicated node? So I made some changes to the code.