### PR TITLE
solve panic.

### DIFF
--- a/lru/lru.go
+++ b/lru/lru.go
@@ -105,7 +105,10 @@ func (c *Cache) RemoveOldest() {
 
 func (c *Cache) removeElement(e *list.Element) {
 	c.ll.Remove(e)
-	kv := e.Value.(*entry)
+	kv, ok := e.Value.(*entry)
+	if !ok {
+		return
+	}
 	delete(c.cache, kv.key)
 	if c.OnEvicted != nil {
 		c.OnEvicted(kv.key, kv.value)


### PR DESCRIPTION
solve panic in:
https://github.com/golang/groupcache/issues/145

The same issue happened to me. I add RWMutex outside and add `RLock` before get and `Lock` before Add. But outside lock seems not work, I got the same panic.
It seems that a type check is needed.
memory leak would be involved since `delete(c.cache, kv.key)` maybe ignored.
