### PR TITLE
groupcache: add go.mod, update for Go 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/golang/groupcache
+
+go 1.20
+
+require github.com/golang/protobuf v1.5.4
+
+require google.golang.org/protobuf v1.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/groupcache.go
+++ b/groupcache.go
@@ -171,6 +171,10 @@ type Group struct {
 
 	// Stats are statistics on the group.
 	Stats Stats
+
+	// rand is only non-nil when testing,
+	// to get predictable results in TestPeers.
+	rand *rand.Rand
 }
 
 // flightGroup is defined as an interface which flightgroup.Group
@@ -315,7 +319,13 @@ func (g *Group) getFromPeer(ctx context.Context, peer ProtoGetter, key string) (
 	// TODO(bradfitz): use res.MinuteQps or something smart to
 	// conditionally populate hotCache.  For now just do it some
 	// percentage of the time.
-	if rand.Intn(10) == 0 {
+	var pop bool
+	if g.rand != nil {
+		pop = g.rand.Intn(10) == 0
+	} else {
+		pop = rand.Intn(10) == 0
+	}
+	if pop {
 		g.populateCache(key, value, &g.hotCache)
 	}
 	return value, nil

--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -253,7 +253,6 @@ func (p fakePeers) PickPeer(key string) (peer ProtoGetter, ok bool) {
 // TestPeers tests that peers (virtual, in-process) are hit, and how much.
 func TestPeers(t *testing.T) {
 	once.Do(testSetup)
-	rand.Seed(123)
 	peer0 := &fakePeer{}
 	peer1 := &fakePeer{}
 	peer2 := &fakePeer{}
@@ -265,6 +264,7 @@ func TestPeers(t *testing.T) {
 		return dest.SetString("got:" + key)
 	}
 	testGroup := newGroup("TestPeers-group", cacheSize, GetterFunc(getter), peerList)
+	testGroup.rand = rand.New(rand.NewSource(123))
 	run := func(name string, n int, wantSummary string) {
 		// Reset counters
 		localHits = 0


### PR DESCRIPTION
Add a go.mod file.

As of Go 1.24 rand.Seed is a no-op. Change TestPeers to use an explicit rand.Rand instead.